### PR TITLE
Update setup.py to work with pip-21

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,27 +2,17 @@ import os
 import io
 from setuptools import setup
 
-filepath = os.path.abspath(os.path.dirname(__file__))
-
 long_description = io.open('README.md', encoding='utf-8').read()
 
-package = {
-    'name': 'dash_bio_utils',
-    'version': '0.0.5',
-    'author': 'The Plotly Team',
-    'author_email': 'dashbio@plot.ly',
-    'description': 'Simple parsing tools that supplement dash-bio.'
-}
-
 setup(
-    name=package['name'],
-    version=package['version'],
+    name='dash_bio_utils',
+    version='0.0.5',
     url='http://github.com/plotly/dash-bio-utils',
-    author=package['author'],
+    author='The Plotly Team',
     author_email='dashbio@plot.ly',
-    packages=[package['name']],
+    packages=['dash_bio_utils'],
     include_package_data=True,
-    description=package['description'],
+    description='Simple parsing tools that supplement dash-bio.',
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ filepath = os.path.abspath(os.path.dirname(__file__))
 long_description = io.open('README.md', encoding='utf-8').read()
 
 package = {
-    'name': os.path.basename(filepath).replace('-', '_'),
+    'name': 'dash_bio_utils',
     'version': '0.0.5',
     'author': 'The Plotly Team',
     'author_email': 'dashbio@plot.ly',
@@ -17,7 +17,7 @@ package = {
 setup(
     name=package['name'],
     version=package['version'],
-    url='http://github.com/plotly/{}'.format(package['name'].replace('_', '-')),
+    url='http://github.com/plotly/dash-bio-utils',
     author=package['author'],
     author_email='dashbio@plot.ly',
     packages=[package['name']],


### PR DESCRIPTION
The following error will appear if we try to install this library with pip-21:
```
    ERROR: Command errored out with exit status 1:
     command: /home/xhlu/miniconda3/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/xhlu/dev/dash-bio-utils/setup.py'"'"'; __file__='"'"'/home/xhlu/dev/dash-bio-utils/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-h2keryx5
         cwd: /home/xhlu/dev/dash-bio-utils/
    Complete output (8 lines):
    running egg_info
    creating /tmp/pip-pip-egg-info-h2keryx5/dash_bio_utils.egg-info
    writing /tmp/pip-pip-egg-info-h2keryx5/dash_bio_utils.egg-info/PKG-INFO
    writing dependency_links to /tmp/pip-pip-egg-info-h2keryx5/dash_bio_utils.egg-info/dependency_links.txt
    writing requirements to /tmp/pip-pip-egg-info-h2keryx5/dash_bio_utils.egg-info/requires.txt
    writing top-level names to /tmp/pip-pip-egg-info-h2keryx5/dash_bio_utils.egg-info/top_level.txt
    writing manifest file '/tmp/pip-pip-egg-info-h2keryx5/dash_bio_utils.egg-info/SOURCES.txt'
    error: package directory 'dash-bio-utils' does not exist
    ----------------------------------------
WARNING: Discarding file:///home/xhlu/dev/dash-bio-utils. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```